### PR TITLE
toggle-resolution script is broken

### DIFF
--- a/acpi-eeepc-generic-toggle-resolution.sh
+++ b/acpi-eeepc-generic-toggle-resolution.sh
@@ -20,11 +20,11 @@
 
 tmp_xrandr="$EEEPC_VAR/lvds-modes"
 
-if [ -e "$tmp_xrandr" ]; then
-    LVDS_XRANDR=$(cat $tmp_xrandr)
-else
+#if [ -e "$tmp_xrandr" ]; then
+#    LVDS_XRANDR=$(cat $tmp_xrandr)
+#else
     LVDS_XRANDR=$(xrandr > $tmp_xrandr)
-fi
+#fi
 
 LVDS_MODES=$(cat $tmp_xrandr | grep -F -e LVDS -A 12 | grep [0-9]x[0-9] | grep -v -e LVDS | awk '{printf $1" "}')
 LVDS_CURRENT=$(cat $tmp_xrandr | grep -F -e LVDS -A 12 | grep -F -e [0-9]x[0-9] -e "*" | awk '{print $1}')


### PR DESCRIPTION
Current script takes current mode from `$EEEPC_VAR/lvds-modes` but doesn't regenerate it. So it switches mode only once instead of looping. The best way to get current mode is from `xrandr`, so we need to call it every time instead of caching. Here is a minimal fix for the problem so toggle-resolution works.
